### PR TITLE
chore(cleanupEffect): better method to clean effects

### DIFF
--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -130,12 +130,7 @@ export class ReactiveEffect<T = any> {
 
 function cleanupEffect(effect: ReactiveEffect) {
   const { deps } = effect
-  if (deps.length) {
-    for (let i = 0; i < deps.length; i++) {
-      deps[i].delete(effect)
-    }
-    deps.length = 0
-  }
+  deps.length = 0
 }
 
 export interface DebuggerOptions {


### PR DESCRIPTION
I don't know why we should manually delete each element when clearing the array, i think just make it length to 0 is a better method